### PR TITLE
Don't require a license

### DIFF
--- a/tdf/extensionuploadcenter/euprelease.py
+++ b/tdf/extensionuploadcenter/euprelease.py
@@ -143,7 +143,7 @@ class IEUpRelease(model.Schema):
         title=_(u'License of the uploaded file'),
         description=_(u"Please mark one or more licenses you publish your release."),
         value_type=schema.Choice(source=vocabAvailLicenses),
-        required=True,
+        required=False,
     )
 
     form.widget(compatibility_choice=CheckBoxFieldWidget)
@@ -302,11 +302,6 @@ class IEUpRelease(model.Schema):
         value_type=schema.Choice(source=vocabAvailPlatforms),
         required=False,
     )
-
-    @invariant
-    def licensenotchoosen(value):
-        if not value.licenses_choice:
-            raise Invalid(_(u"Please choose a license for your release."))
 
     @invariant
     def compatibilitynotchoosen(data):


### PR DESCRIPTION
The license field only contains a small number of Open Source licenses.
Why do you want to forbid extensions that have a different license?